### PR TITLE
Fix YAML closing for Vercel step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,6 @@ jobs:
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-args: ${{ github.event_name == 'pull_request' && '--prebuilt' || '--prod' }}
+          vercel-args: >-
+            ${{ github.event_name == 'pull_request' && '--prebuilt' || '--prod' }}
           working-directory: .


### PR DESCRIPTION
## Summary
- close the Vercel deploy step in CI workflow using folded syntax

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: disable}}' .github/workflows/ci.yml`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6870f85ac7ac832887ac03b8ab51b7db