### PR TITLE
Add functional pages and routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DropFlow</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dropflow",
       "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.39.6",
         "axios": "^1.6.5",
         "clsx": "^1.2.1",
         "framer-motion": "^12.23.0",
@@ -1211,6 +1212,81 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
+      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.50.5",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.50.5.tgz",
+      "integrity": "sha512-FgBFYJ/nsBBN1o4qmQpx1ouupht256FCxNM6r5YTgwGbOVopODzP2xhZPu2ecXdmU4CxTS5/KiGf5j2l3ACozQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.70.0",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1295,11 +1371,16 @@
       "version": "24.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
       "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -1319,6 +1400,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2298,6 +2388,21 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3357,6 +3462,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3891,7 +4002,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3998,6 +4108,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4102,6 +4228,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.6.3",
-    "tailwind-variants": "^0.1.0"
+    "tailwind-variants": "^0.1.0",
+    "@supabase/supabase-js": "^2.39.6"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^5.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,8 @@
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
+import routes from './routes'
 
 import Sidebar from './components/Sidebar'
-
-// Pages principales
-import Home from './pages/Home'
-import Import from './pages/Import'
-import Tracking from './pages/Tracking'
-import SEO from './pages/SEO'
-import Blog from './pages/Blog'
-import CRM from './pages/CRM'
-import Winners from './pages/Winners'
-import Marketplace from './pages/Marketplace'
-import Marketing from './pages/Marketing'
-import Reviews from './pages/Reviews'
-import SyncShopifyAdvanced from './pages/SyncShopifyAdvanced'
-import OptimisationAI from './pages/OptimisationAI'
-
-// Auth & Dashboard
-import Auth from './pages/Auth'
-import Register from './pages/Register'
-import Dashboard from './pages/Dashboard'
 
 const App: React.FC = () => {
   return (
@@ -28,24 +10,9 @@ const App: React.FC = () => {
       <Sidebar />
       <main className="flex-1 p-6 overflow-auto">
         <Routes>
-          {/* Pages principales */}
-          <Route path="/" element={<Home />} />
-          <Route path="/import" element={<Import />} />
-          <Route path="/tracking" element={<Tracking />} />
-          <Route path="/seo" element={<SEO />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/crm" element={<CRM />} />
-          <Route path="/winners" element={<Winners />} />
-          <Route path="/marketplace" element={<Marketplace />} />
-          <Route path="/marketing" element={<Marketing />} />
-          <Route path="/reviews" element={<Reviews />} />
-          <Route path="/sync-shopify" element={<SyncShopifyAdvanced />} />
-          <Route path="/optimisation" element={<OptimisationAI />} />
-
-          {/* Authentification */}
-          <Route path="/auth" element={<Auth />} />
-          <Route path="/register" element={<Register />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          {routes.map((r) => (
+            <Route key={r.path} path={r.path} element={r.element} />
+          ))}
         </Routes>
       </main>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,1 +1,21 @@
-// TODO: Implement Sidebar.tsx
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+import routes from '@/routes'
+
+export default function Sidebar() {
+  return (
+    <aside className="w-56 border-r p-4 space-y-2 bg-white">
+      {routes.map((route) => (
+        <NavLink
+          key={route.path}
+          to={route.path}
+          className={({ isActive }) =>
+            isActive ? 'font-semibold block' : 'text-gray-600 block'
+          }
+        >
+          {route.label}
+        </NavLink>
+      ))}
+    </aside>
+  )
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,1 +1,22 @@
-// TODO: Implement button.tsx
+import React from 'react'
+import clsx from 'clsx'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={clsx(
+        'px-4 py-2 rounded bg-primary text-primary-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+)
+
+Button.displayName = 'Button'
+
+export default Button

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,1 +1,21 @@
-// TODO: Implement card.tsx
+import React from 'react'
+
+export interface CardProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function Card({ children, className }: CardProps) {
+  return <div className={`rounded border bg-white shadow ${className ?? ''}`}>{children}</div>
+}
+
+export interface CardContentProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function CardContent({ children, className }: CardContentProps) {
+  return <div className={className}>{children}</div>
+}
+
+export default Card

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,1 +1,19 @@
-// TODO: Implement input.tsx
+import React from 'react'
+import clsx from 'clsx'
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={clsx('border px-3 py-2 rounded w-full', className)}
+      {...props}
+    />
+  )
+)
+
+Input.displayName = 'Input'
+
+export default Input

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,1 +1,19 @@
-// TODO: Implement select.tsx
+import React from 'react'
+import clsx from 'clsx'
+
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={clsx('border px-3 py-2 rounded', className)}
+      {...props}
+    />
+  )
+)
+
+Select.displayName = 'Select'
+
+export default Select

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,1 +1,12 @@
-// TODO: Implement toast.tsx
+import React from 'react'
+
+export interface ToastProps {
+  message: string
+  className?: string
+}
+
+export default function Toast({ message, className }: ToastProps) {
+  return (
+    <div className={`rounded bg-black text-white px-4 py-2 ${className ?? ''}`}>{message}</div>
+  )
+}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Blog.tsx
+import React from 'react'
+
+export default function Blog() {
+  return <div className="p-4">Blog</div>
+}

--- a/src/pages/CRM.tsx
+++ b/src/pages/CRM.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement CRM.tsx
+import React from 'react'
+
+export default function CRM() {
+  return <div className="p-4">CRM</div>
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Home.tsx
+import React from 'react'
+
+export default function Home() {
+  return <div className="p-4">Accueil</div>
+}

--- a/src/pages/Import.tsx
+++ b/src/pages/Import.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Import.tsx
+import React from 'react'
+
+export default function Import() {
+  return <div className="p-4">Importation</div>
+}

--- a/src/pages/Marketing.tsx
+++ b/src/pages/Marketing.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Marketing.tsx
+import React from 'react'
+
+export default function Marketing() {
+  return <div className="p-4">Marketing</div>
+}

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Marketplace.tsx
+import React from 'react'
+
+export default function Marketplace() {
+  return <div className="p-4">Marketplace</div>
+}

--- a/src/pages/OptimisationAI.tsx
+++ b/src/pages/OptimisationAI.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement OptimisationAI.tsx
+import React from 'react'
+
+export default function OptimisationAI() {
+  return <div className="p-4">Optimisation AI</div>
+}

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Reviews.tsx
+import React from 'react'
+
+export default function Reviews() {
+  return <div className="p-4">Reviews</div>
+}

--- a/src/pages/SEO.tsx
+++ b/src/pages/SEO.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement SEO.tsx
+import React from 'react'
+
+export default function SEO() {
+  return <div className="p-4">SEO</div>
+}

--- a/src/pages/SyncShopifyAdvanced.tsx
+++ b/src/pages/SyncShopifyAdvanced.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement SyncShopifyAdvanced.tsx
+import React from 'react'
+
+export default function SyncShopifyAdvanced() {
+  return <div className="p-4">Synchronisation Shopify</div>
+}

--- a/src/pages/Tracking.tsx
+++ b/src/pages/Tracking.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Tracking.tsx
+import React from 'react'
+
+export default function Tracking() {
+  return <div className="p-4">Tracking</div>
+}

--- a/src/pages/Winners.tsx
+++ b/src/pages/Winners.tsx
@@ -1,1 +1,5 @@
-// TODO: Implement Winners.tsx
+import React from 'react'
+
+export default function Winners() {
+  return <div className="p-4">Produits Gagnants</div>
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,1 +1,43 @@
-// TODO: Implement routes.tsx
+import React from 'react'
+
+import Home from './pages/Home'
+import Import from './pages/Import'
+import Tracking from './pages/Tracking'
+import SEO from './pages/SEO'
+import Blog from './pages/Blog'
+import CRM from './pages/CRM'
+import Winners from './pages/Winners'
+import Marketplace from './pages/Marketplace'
+import Marketing from './pages/Marketing'
+import Reviews from './pages/Reviews'
+import SyncShopifyAdvanced from './pages/SyncShopifyAdvanced'
+import OptimisationAI from './pages/OptimisationAI'
+import Auth from './pages/Auth'
+import Register from './pages/Register'
+import Dashboard from './pages/Dashboard'
+
+export interface AppRoute {
+  path: string
+  element: React.ReactElement
+  label: string
+}
+
+const routes: AppRoute[] = [
+  { path: '/', element: <Home />, label: 'Accueil' },
+  { path: '/import', element: <Import />, label: 'Import' },
+  { path: '/tracking', element: <Tracking />, label: 'Tracking' },
+  { path: '/seo', element: <SEO />, label: 'SEO' },
+  { path: '/blog', element: <Blog />, label: 'Blog' },
+  { path: '/crm', element: <CRM />, label: 'CRM' },
+  { path: '/winners', element: <Winners />, label: 'Winners' },
+  { path: '/marketplace', element: <Marketplace />, label: 'Marketplace' },
+  { path: '/marketing', element: <Marketing />, label: 'Marketing' },
+  { path: '/reviews', element: <Reviews />, label: 'Reviews' },
+  { path: '/sync-shopify', element: <SyncShopifyAdvanced />, label: 'Sync Shopify' },
+  { path: '/optimisation', element: <OptimisationAI />, label: 'Optimisation' },
+  { path: '/auth', element: <Auth />, label: 'Connexion' },
+  { path: '/register', element: <Register />, label: 'Inscription' },
+  { path: '/dashboard', element: <Dashboard />, label: 'Dashboard' },
+]
+
+export default routes


### PR DESCRIPTION
## Summary
- flesh out placeholder UI components and sidebar
- implement functional placeholder pages
- centralize route definitions and update app
- add required dependencies and basic index.html

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870f856b47c8328b222de6deb6d1b29