### PR TITLE
Add router configuration

### DIFF
--- a/extension_chrome/manifest.json
+++ b/extension_chrome/manifest.json
@@ -1,1 +1,8 @@
-// TODO: Implement manifest.json
+{
+  "manifest_version": 3,
+  "name": "Dropflow Extension",
+  "version": "1.0.0",
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dropflow</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dropflow",
       "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.43.0",
         "axios": "^1.6.5",
         "clsx": "^1.2.1",
         "framer-motion": "^12.23.0",
@@ -1211,6 +1212,81 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.52.0.tgz",
+      "integrity": "sha512-jbs3CV1f2+ge7sgBeEduboT9v/uGjF22v0yWi/5/XFn5tbM8MfWRccsMtsDwAwu24XK8H6wt2LJDiNnZLtx/bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1295,11 +1371,16 @@
       "version": "24.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
       "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -1319,6 +1400,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2298,6 +2388,21 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3357,6 +3462,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3891,7 +4002,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3998,6 +4108,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4102,6 +4228,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.6.3",
-    "tailwind-variants": "^0.1.0"
+    "tailwind-variants": "^0.1.0",
+    "@supabase/supabase-js": "^2.43.0"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^5.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,9 @@
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
 
+import { routes } from './routes'
+
 import Sidebar from './components/Sidebar'
-
-// Pages principales
-import Home from './pages/Home'
-import Import from './pages/Import'
-import Tracking from './pages/Tracking'
-import SEO from './pages/SEO'
-import Blog from './pages/Blog'
-import CRM from './pages/CRM'
-import Winners from './pages/Winners'
-import Marketplace from './pages/Marketplace'
-import Marketing from './pages/Marketing'
-import Reviews from './pages/Reviews'
-import SyncShopifyAdvanced from './pages/SyncShopifyAdvanced'
-import OptimisationAI from './pages/OptimisationAI'
-
-// Auth & Dashboard
-import Auth from './pages/Auth'
-import Register from './pages/Register'
-import Dashboard from './pages/Dashboard'
 
 const App: React.FC = () => {
   return (
@@ -28,24 +11,9 @@ const App: React.FC = () => {
       <Sidebar />
       <main className="flex-1 p-6 overflow-auto">
         <Routes>
-          {/* Pages principales */}
-          <Route path="/" element={<Home />} />
-          <Route path="/import" element={<Import />} />
-          <Route path="/tracking" element={<Tracking />} />
-          <Route path="/seo" element={<SEO />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/crm" element={<CRM />} />
-          <Route path="/winners" element={<Winners />} />
-          <Route path="/marketplace" element={<Marketplace />} />
-          <Route path="/marketing" element={<Marketing />} />
-          <Route path="/reviews" element={<Reviews />} />
-          <Route path="/sync-shopify" element={<SyncShopifyAdvanced />} />
-          <Route path="/optimisation" element={<OptimisationAI />} />
-
-          {/* Authentification */}
-          <Route path="/auth" element={<Auth />} />
-          <Route path="/register" element={<Register />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          {routes.map((route, idx) => (
+            <Route key={idx} path={route.path} element={route.element} />
+          ))}
         </Routes>
       </main>
     </div>

--- a/src/pages/OpenAI.tsx
+++ b/src/pages/OpenAI.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function OpenAI() {
+  return <div className="p-4">{/* openai page */}</div>;
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,1 +1,35 @@
-// TODO: Implement routes.tsx
+import React from 'react'
+
+import Home from './pages/Home'
+import Auth from './pages/Auth'
+import Dashboard from './pages/Dashboard'
+import Import from './pages/Import'
+import Tracking from './pages/Tracking'
+import SEO from './pages/SEO'
+import Blog from './pages/Blog'
+import CRM from './pages/CRM'
+import Winners from './pages/Winners'
+import Marketplace from './pages/Marketplace'
+import Marketing from './pages/Marketing'
+import Reviews from './pages/Reviews'
+import SyncShopifyAdvanced from './pages/SyncShopifyAdvanced'
+import OptimisationAI from './pages/OptimisationAI'
+import Register from './pages/Register'
+
+export const routes = [
+  { path: '/', element: <Home /> },
+  { path: '/auth', element: <Auth /> },
+  { path: '/dashboard', element: <Dashboard /> },
+  { path: '/import', element: <Import /> },
+  { path: '/tracking', element: <Tracking /> },
+  { path: '/seo', element: <SEO /> },
+  { path: '/blog', element: <Blog /> },
+  { path: '/crm', element: <CRM /> },
+  { path: '/winners', element: <Winners /> },
+  { path: '/marketplace', element: <Marketplace /> },
+  { path: '/marketing', element: <Marketing /> },
+  { path: '/reviews', element: <Reviews /> },
+  { path: '/sync-shopify', element: <SyncShopifyAdvanced /> },
+  { path: '/optimisation', element: <OptimisationAI /> },
+  { path: '/register', element: <Register /> },
+]


### PR DESCRIPTION
## Summary
- add a dedicated `routes.tsx` file exporting an array of React Router routes
- simplify `App.tsx` to consume the central route configuration
- add missing `index.html` required by Vite
- fix Prettier syntax errors by replacing placeholder manifest and OpenAI page
- install `@supabase/supabase-js` for supabase integration

## Testing
- `npx prettier --write index.html extension_chrome/manifest.json src/pages/OpenAI.tsx package.json package-lock.json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d0b13e110832886314361531ff607