### PR TITLE
Fix invalid page component name and extension

### DIFF
--- a/src/pages/openai.ts
+++ b/src/pages/openai.ts
@@ -1,6 +1,0 @@
-import React from 'react'
-
-export default function openai.ts() {
-  return <div className="p-4">{/* openai.ts */}</div>
-}
-      

--- a/src/pages/openai.tsx
+++ b/src/pages/openai.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export default function OpenAIPage() {
+  return <div className="p-4">{/* openai.tsx */}</div>
+}
+      


### PR DESCRIPTION
## Summary
- rename invalid component `openai.ts` -> `openai.tsx`
- rename default export to `OpenAIPage`

## Testing
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_687d0b227c588328bf65146665d07ad8