### PR TITLE
Add Select and Toast components

### DIFF
--- a/__tests__/Profile.test.tsx
+++ b/__tests__/Profile.test.tsx
@@ -1,6 +1,11 @@
-import { render } from '@testing-library/react'
-import Profile from '../src/pages/Profile'
+import { render, screen, fireEvent } from "@testing-library/react";
+import Profile from "../src/pages/Profile";
 
-test('renders Profile', () => {
-  render(<Profile />)
-})
+test("renders Profile with select and toast", () => {
+  render(<Profile />);
+  const select = screen.getByTestId("privacy-select");
+  expect(select).toBeInTheDocument();
+  const button = screen.getByRole("button", { name: /save/i });
+  fireEvent.click(button);
+  expect(screen.getByText("Profile saved")).toBeInTheDocument();
+});

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,1 +1,29 @@
-// TODO: Implement select.tsx
+import React from "react";
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
+  options?: { value: string; label: string }[];
+};
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { className = "", options, children, ...props },
+  ref,
+) {
+  return (
+    <select
+      ref={ref}
+      className={`border px-3 py-2 rounded ${className}`}
+      {...props}
+    >
+      {options
+        ? options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))
+        : children}
+    </select>
+  );
+});
+
+export default Select;
+export { Select };

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,1 +1,21 @@
-// TODO: Implement toast.tsx
+import React from "react";
+
+export type ToastProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Toast = React.forwardRef<HTMLDivElement, ToastProps>(function Toast(
+  { className = "", children, ...props },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={`px-4 py-2 rounded bg-gray-800 text-white ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+});
+
+export default Toast;
+export { Toast };

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,26 @@
-import React from 'react'
+import React, { useState } from "react";
+import { Select } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import Toast from "@/components/ui/toast";
 
 export default function Profile() {
-  return <div className="p-4">{/* Profile.tsx */}</div>
+  const [message, setMessage] = useState("");
+
+  const handleSave = () => {
+    setMessage("Profile saved");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <Select
+        data-testid="privacy-select"
+        options={[
+          { value: "public", label: "Public" },
+          { value: "private", label: "Private" },
+        ]}
+      />
+      <Button onClick={handleSave}>Save</Button>
+      {message && <Toast>{message}</Toast>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- implement `Select` component
- implement `Toast` component
- use them in `Profile` page
- extend profile test to verify new behaviour

## Testing
- `npm run format` *(fails: extension_chrome/manifest.json parse error)*

------
https://chatgpt.com/codex/tasks/task_e_687d0b3766c48328a662b83a0066569c