### PR TITLE
Update docs and add links from pages

### DIFF
--- a/docs/Help.md
+++ b/docs/Help.md
@@ -1,3 +1,12 @@
 # Help
 
-Cette page est générée automatiquement par Codex Ultimate.
+Voici comment obtenir de l'aide sur DropFlow.
+
+## Utilisation générale
+
+- Parcourez le tableau de bord pour accéder aux différentes sections.
+- Consultez les pages d'import, de suivi et d'optimisation pour gérer vos produits.
+
+## Support
+
+Si vous rencontrez des problèmes, contactez notre équipe à `support@dropflow.com`.

--- a/docs/Notifications.md
+++ b/docs/Notifications.md
@@ -1,3 +1,4 @@
 # Notifications
 
-Cette page est générée automatiquement par Codex Ultimate.
+DropFlow peut vous informer des nouvelles commandes ou des actions nécessaires.
+Activez ou désactivez les notifications depuis les paramètres de votre compte.

--- a/docs/Pricing.md
+++ b/docs/Pricing.md
@@ -1,3 +1,8 @@
 # Pricing
 
-Cette page est générée automatiquement par Codex Ultimate.
+DropFlow propose deux formules :
+
+- **Gratuit** : accès limité aux fonctionnalités essentielles pour tester la plateforme.
+- **Pro** : synchronisation illimitée et accès à toutes les options d'optimisation.
+
+Les abonnements sont sans engagement et peuvent être annulés à tout moment.

--- a/docs/Privacy.md
+++ b/docs/Privacy.md
@@ -1,3 +1,6 @@
 # Privacy
 
-Cette page est générée automatiquement par Codex Ultimate.
+DropFlow respecte la vie privée de ses utilisateurs.
+
+Nous collectons uniquement les informations nécessaires au fonctionnement du service.
+Aucune donnée personnelle n'est cédée à des tiers sans consentement.

--- a/docs/Profile.md
+++ b/docs/Profile.md
@@ -1,3 +1,4 @@
 # Profile
 
-Cette page est générée automatiquement par Codex Ultimate.
+Cette page explique comment gérer vos informations personnelles sur DropFlow.
+Vous pouvez mettre à jour votre nom, votre email et vos préférences depuis la section Profil de l'application.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1,3 +1,4 @@
 # Settings
 
-Cette page est générée automatiquement par Codex Ultimate.
+Les paramètres vous permettent de personnaliser DropFlow selon vos besoins.
+Vous pouvez y configurer vos clés API, régler les notifications ou choisir la langue de l'interface.

--- a/docs/Subscription.md
+++ b/docs/Subscription.md
@@ -1,3 +1,4 @@
 # Subscription
 
-Cette page est générée automatiquement par Codex Ultimate.
+Cette page décrit comment gérer ou annuler votre abonnement DropFlow.
+Rendez-vous dans la section Abonnement de votre profil pour modifier vos options de facturation.

--- a/docs/Terms.md
+++ b/docs/Terms.md
@@ -1,3 +1,8 @@
 # Terms
 
-Cette page est générée automatiquement par Codex Ultimate.
+En utilisant DropFlow, vous acceptez nos conditions générales d'utilisation.
+
+- Les données fournies doivent être exactes.
+- DropFlow ne peut être tenu responsable d'une mauvaise utilisation de la plateforme.
+
+Consultez la version complète des conditions pour plus de détails.

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Help() {
-  return <div className="p-4">{/* Help.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Help</h1>
+      <p>
+        Pour plus d'informations, consultez la{" "}
+        <a href="/docs/Help.md" className="text-blue-600 underline">
+          documentation d'aide
+        </a>
+        .
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Notifications() {
-  return <div className="p-4">{/* Notifications.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Notifications</h1>
+      <p>
+        Plus d'informations dans la{" "}
+        <a href="/docs/Notifications.md" className="text-blue-600 underline">
+          documentation des notifications
+        </a>
+        .
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Pricing() {
-  return <div className="p-4">{/* Pricing.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Pricing</h1>
+      <p>
+        Découvrez nos offres dans la{" "}
+        <a href="/docs/Pricing.md" className="text-blue-600 underline">
+          page des tarifs
+        </a>
+        .
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Privacy() {
-  return <div className="p-4">{/* Privacy.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Privacy</h1>
+      <p>
+        Détails disponibles dans notre{" "}
+        <a href="/docs/Privacy.md" className="text-blue-600 underline">
+          politique de confidentialité
+        </a>
+        .
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Profile() {
-  return <div className="p-4">{/* Profile.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Profile</h1>
+      <p>
+        Consultez la{" "}
+        <a href="/docs/Profile.md" className="text-blue-600 underline">
+          documentation profil
+        </a>{" "}
+        pour apprendre à modifier vos informations.
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Settings() {
-  return <div className="p-4">{/* Settings.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Settings</h1>
+      <p>
+        Les différentes options sont détaillées dans la{" "}
+        <a href="/docs/Settings.md" className="text-blue-600 underline">
+          documentation des paramètres
+        </a>
+        .
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Subscription() {
-  return <div className="p-4">{/* Subscription.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Subscription</h1>
+      <p>
+        Pour gérer votre abonnement, référez-vous à la{" "}
+        <a href="/docs/Subscription.md" className="text-blue-600 underline">
+          documentation abonnement
+        </a>
+        .
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React from "react";
 
 export default function Terms() {
-  return <div className="p-4">{/* Terms.tsx */}</div>
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-2">Terms</h1>
+      <p>
+        Veuillez lire nos{" "}
+        <a href="/docs/Terms.md" className="text-blue-600 underline">
+          conditions d'utilisation
+        </a>
+        .
+      </p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fill out documentation for help, pricing, terms, privacy and more
- link the corresponding pages in the app to these docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d0b3bb12483289dea40baa6971146